### PR TITLE
fix: update URLs after org rename from 4lando to lando-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A web-based YAML editor for Lando configuration files with real-time validation 
 ## Features
 
 - **🎨 YAML Syntax Highlighting**: Custom syntax highlighting optimized for Landofiles
-- **✅ Real-time Validation**: Validates against the community-driven [Lando schema specification](https://github.com/4lando/lando-spec)
+- **✅ Real-time Validation**: Validates against the community-driven [Lando schema specification](https://github.com/lando-community/lando-spec)
 - **🔄 Auto-formatting**: Automatically formats:
   - On file load
   - When pasting content
@@ -29,7 +29,7 @@ A web-based YAML editor for Lando configuration files with real-time validation 
   - Save with auto-naming
   - Preserves comments and structure
 
-All schema-powered features (validation, suggestions, hover tooltips, etc) are driven by the community-driven [Lando schema specification](https://github.com/4lando/lando-spec), ensuring accuracy and consistency with Lando's configuration format.
+All schema-powered features (validation, suggestions, hover tooltips, etc) are driven by the community-driven [Lando schema specification](https://github.com/lando-community/lando-spec), ensuring accuracy and consistency with Lando's configuration format.
 
 ## Usage
 
@@ -85,7 +85,7 @@ The editor will be available at `https://editor.lndo.site/public`.
 ### Deployment
 
 The editor is automatically deployed to GitHub Pages when code is pushed to the main branch.
-You can access the live version at: https://4lando.github.io/editor/
+You can access the live version at: https://lando-community.github.io/editor/
 
 ## Tech Stack
 

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                     </div>
                 </div>
                 <div class="flex items-center gap-4">
-                    <a href="https://github.com/4lando/editor" target="_blank" rel="noopener noreferrer"
+                    <a href="https://github.com/lando-community/editor" target="_blank" rel="noopener noreferrer"
                         class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
                         aria-label="View source on GitHub">
                         <!-- GitHub icon -->
@@ -124,7 +124,7 @@
 
         <footer class="mt-8 text-center text-sm text-gray-600 dark:text-gray-400">
             <p>
-                Validation powered by the <a href="https://github.com/4lando/lando-spec" target="_blank"
+                Validation powered by the <a href="https://github.com/lando-community/lando-spec" target="_blank"
                     rel="noopener noreferrer" class="text-[#df4090] hover:underline">Lando Schema Specification</a>
             </p>
         </footer>

--- a/src/content/usage-instructions.jsx
+++ b/src/content/usage-instructions.jsx
@@ -5,7 +5,7 @@ export const usageInstructions = (
     <p className="mb-4 text-gray-600 dark:text-gray-300">
       The editor validates your Landofile configuration against the{" "}
       <a
-        href="https://github.com/4lando/lando-spec"
+        href="https://github.com/lando-community/lando-spec"
         target="_blank"
         rel="noopener noreferrer"
         className="text-[#df4090] hover:underline"

--- a/src/lib/schema-validation.js
+++ b/src/lib/schema-validation.js
@@ -65,7 +65,7 @@ export async function loadSchema() {
     }
 
     if (!schema) {
-      const schemaUrl = "https://4lando.github.io/lando-spec/landofile-spec.json";
+      const schemaUrl = "https://lando-community.github.io/lando-spec/landofile-spec.json";
       debug.log("Fetching schema from:", schemaUrl);
 
       const response = await fetch(schemaUrl);


### PR DESCRIPTION
The `4lando` GitHub org was renamed to `lando-community`. While GitHub redirects repository URLs automatically, **GitHub Pages URLs do not redirect** — meaning `4lando.github.io` returns 404.

This updates all references from `4lando` to `lando-community` to fix broken URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a URL-only update, but it affects the remote schema fetch endpoint, so a wrong URL would break validation/completions at runtime.
> 
> **Overview**
> Updates all user-facing and runtime references from the old `4lando` GitHub org to `lando-community`.
> 
> This includes README links and the deployed editor URL, the UI’s GitHub and schema links in `index.html`/`usage-instructions.jsx`, and the schema download endpoint in `src/lib/schema-validation.js` (switching the GitHub Pages JSON schema URL to `lando-community.github.io`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26461cebdae7594c0673a478264bda1df56b5d9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->